### PR TITLE
Change old ttf to the new release that supports Emoji 15.0

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=blobmoji
 name=Blobmoji
-version=Emoji 14
-versionCode=3
+version=Emoji 15
+versionCode=4
 author=kidonng
 description=Noto Emoji font with Blobs enabled (https://github.com/kidonng/magisk-blobmoji)


### PR DESCRIPTION
Fixes #2.

- Downloaded the Blobmoji.ttf font from https://github.com/C1710/blobmoji/releases/tag/v15.0
- Moved file to `magisk-blobmoji/system/fonts/`
- While in that directory, ran `mv Blobmoji.ttf NotoColorEmoji.ttf`

Note that **I did not test this change**.